### PR TITLE
v0.1.0 Meeting MijnAgenda 2026-04-13

### DIFF
--- a/apis/rest/afspraken/v0.1.0.yaml
+++ b/apis/rest/afspraken/v0.1.0.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: MijnAgenda
-  version: next
+  version: 0.1.0-concept
   description: |
     **Conceptversie — datamodel onder actieve ontwikkeling**
 


### PR DESCRIPTION
- Geen landnaam / landcode, alleen drie adresregels
- Timezone UTC bij teruggave, bij posten mag het offsets hebben
- Niet verplichten van E.164 voor telefoonnumers (wel aanbevelen)
- 2 afpsraaktypes voor Online en Offline
- Hernoemen naar MijnAgenda (geen Afspraken)
- Geen `include` of `extended` vooralsnog - details los opvragen