### PR TITLE
Pin packageManager op pnpm@10.26.0 (fix Docker/Fly build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vng-api-lab",
   "version": "1.0.0",
   "description": "VNG API lab — APIs, Schemas en Patterns",
+  "packageManager": "pnpm@10.26.0",
   "author": {
     "name": "Joep Meindertsma"
   },


### PR DESCRIPTION
De Fly/Docker-build (`node:20-alpine` + `corepack enable && pnpm install`) faalde omdat corepack zonder pin de nieuwste pnpm (11.7.0) downloadt, die Node >=22.13 vereist (`node:sqlite`).

Deze pin zet pnpm op 10.26.0 — gelijk aan wat CI gebruikt (`npx pnpm@10.26.0`) en compatibel met `lockfileVersion: 9.0`.

Eénregelige fix; geen functionele wijziging.