### PR TITLE
ADR's en patronen aan elkaar koppelen, plus ADR-0007 (open data via pull-feed) + patterns/sync-feed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,21 @@ Wijzigingsverzoeken starten bij voorkeur als issue. Concrete uitwerkingen en spe
 
 Nieuwe ideeën beginnen altijd als een **GitHub Issue**. Gebruik hiervoor het template "Businesswens". De Communitymanager beoordeelt of de wens aansluit bij de roadmap en of er al bestaande oplossingen zijn.
 
-### 2. Ontwerp (RFC)
+### 2. Ontwerp (ADR)
 
-Voor grote wijzigingen of nieuwe services maken we een Architectural Decision Record (ADR) of RFC in de `docs/rfcs/` folder. Dit wordt getoetst door de Tech Lead en de relevante PO.
+Voor grote wijzigingen of nieuwe services maken we een Architectural Decision Record (ADR) in [`architecture/adr/`](architecture/adr/README.md). Dit wordt getoetst door de Tech Lead en de relevante PO. Die map bevat ook het stramien voor een nieuwe ADR en een index van de bestaande besluiten.
+
+Een ADR legt vast *waarom* iets zo is besloten, inclusief de alternatieven die zijn afgevallen — juist dat laatste is wat je nodig hebt als de context over een jaar verandert.
+
+### 2a. Van besluit naar bouwblok
+
+Volgt uit een ADR een herbruikbaar stuk API-contract, dan landt dat als patroon in `patterns/`. Houd de verwijzing tweezijdig:
+
+- het patroon opent met `# Implementeert: ADR-XXXX (…)`;
+- de ADR krijgt een korte `## Bouwblok`-sectie die naar het patroon wijst;
+- de tabel in [`architecture/adr/README.md`](architecture/adr/README.md) is de autoritatieve afbeelding tussen beide.
+
+Een patroon zonder onderliggende ADR benoemt in één regel zijn herkomst, zodat "geen ADR" zichtbaar een keuze is en geen omissie.
 
 ### 3. Implementatie (Pull Request)
 

--- a/architecture/adr/0001-federatief-geen-centrale-kluis.md
+++ b/architecture/adr/0001-federatief-geen-centrale-kluis.md
@@ -29,6 +29,12 @@ De strategie zweeft tussen twee modellen: "consumers halen CloudEvents op bij de
 - Federatie over heterogene bronnen vereist een discovery/verwijsindex en, voor legacy, adapters.
 - Een cache blijft een kopie — bewust begrensd (korte TTL, crypto-shred), geen replica-of-record.
 
+## Bouwblokken
+
+Dit besluit is richtinggevend en heeft geen eigen patroon; het werkt door in
+[ADR-0005](./0005-dunne-gateway-client-side-aggregatie.md) (lees-laag) en
+[ADR-0007](./0007-open-data-publicatie-pull-feed.md) (publicatie van open data).
+
 ## Relatie tot de strategie
 
 Maakt de impliciete "bij de bron"-lijn expliciet en kiest die boven het centrale leesmodel.

--- a/architecture/adr/0002-levering-snapshot-plus-sse.md
+++ b/architecture/adr/0002-levering-snapshot-plus-sse.md
@@ -37,6 +37,16 @@ Event sourcing verdwijnt als publiek contract; CloudEvents verhuist naar de **in
 - Een gemultiplexte multi-bron-stream heeft alleen *arrival order*, geen globale totale ordening.
 - Cold start vereist een snapshot; een pure tail mist historie.
 
+## Bouwblok
+
+[`patterns/sync-feed`](../../patterns/sync-feed/next.yaml) levert de snapshot- en
+cursorbouwstenen uit dit besluit als herbruikbare OpenAPI-fragmenten. Dat patroon
+adresseert ook het AVG-bezwaar uit dit besluit: het kent een expliciete
+`redact`-operatie, waarmee een log redigeerbaar wordt en gaten in de reeks
+benoemd worden in plaats van stil te blijven. Zie ook
+[ADR-0007](./0007-open-data-publicatie-pull-feed.md), dat voor open data de
+pull-feed als primaire route kiest en de stream optioneel maakt.
+
 ## Relatie tot de strategie
 
 Behoudt het idee van events/CloudEvents, maar verschuift het van "event sourcing als leescontract" naar "snapshot + SSE voor lezen, CloudEvents voor ingest".

--- a/architecture/adr/0003-begrensde-query-grammatica.md
+++ b/architecture/adr/0003-begrensde-query-grammatica.md
@@ -30,6 +30,13 @@ Domein-specifieke views (WOZ, Parkeren, Belasting) zijn **query-templates** bove
 - Dekt niet elke exotische zoekvraag — bewust geaccepteerd; gecontroleerd uitbreidbaar.
 - Full-text over de hele dataset blijft een aandachtspunt voor privacy/ABAC.
 
+## Bouwblok
+
+De cursor-paginering die dit besluit voorschrijft staat als herbruikbaar
+fragment in [`patterns/sync-feed`](../../patterns/sync-feed/next.yaml). Let op dat
+[`patterns/pagination`](../../patterns/pagination/0.0.1.yaml) nog `page`/`pageSize`
+gebruikt en dus niet aan dit besluit voldoet.
+
 ## Relatie tot de strategie
 
 Behoudt het generieke query-idee en de domein-templates, maar begrenst de grammatica i.p.v. een vrije Elastic-DSL te standaardiseren.

--- a/architecture/adr/0004-ingest-cloudevents-push.md
+++ b/architecture/adr/0004-ingest-cloudevents-push.md
@@ -35,6 +35,16 @@ Dit kan naar een **self-hosted** lees-API óf naar een **per-domein register** (
 - Kleine leveranciers moeten alsnog outbox + retry bouwen (minder dan een query-API, niet nul).
 - Vereist een PKI/ondertekening-afsprakenstelsel.
 
+## Bouwblok
+
+De CloudEvents-envelop staat in [`schemas/events`](../../schemas/events/v0.0.1.json),
+inclusief `sequence`/`sequencetype` en `dataref` (verwijzing in plaats van inline
+inhoud).
+
+**Reikwijdte:** dit besluit geldt voor gegevens met een autorisatievraag.
+Voor publicatie van open data is het afgebakend door
+[ADR-0007](./0007-open-data-publicatie-pull-feed.md).
+
 ## Relatie tot de strategie
 
 Lost het expliciet benoemde sync-/dataverlies-probleem op, en geeft CloudEvents een concrete, verdedigbare rol (ingest i.p.v. publiek leescontract).

--- a/architecture/adr/0005-dunne-gateway-client-side-aggregatie.md
+++ b/architecture/adr/0005-dunne-gateway-client-side-aggregatie.md
@@ -33,6 +33,12 @@ Géén business-logica, géén merge, géén persistente opslag in de gateway. P
 - De gateway concentreert nog steeds toegang (zij het zonder merge/opslag) → ABAC óók bij de bron, verwerkingslogging, meerdere gateways i.p.v. één nationale.
 - Pure-client blijft alleen haalbaar bij beperkte, CORS-coöperatieve bronnen.
 
+## Bouwblok
+
+[`patterns/federated-auth`](../../patterns/federated-auth/next.yaml) legt de
+OAuth2-bouwstenen vast waarmee een API rechtstreeks door een publieke client kan
+worden aangeroepen — de contractkant van dit besluit.
+
 ## Relatie tot de strategie
 
 Vult een laag in die de strategie niet behandelde (hoe komt het samen voor de burger), consistent met OIDC-NLGOV en ABAC.

--- a/architecture/adr/0006-per-domein-registers.md
+++ b/architecture/adr/0006-per-domein-registers.md
@@ -36,6 +36,12 @@ Registers zijn **per domein gesharded**, nooit één nationale alle-burgerdata-p
 - Per-domein trust-concentratie en SLA/aansprakelijkheid blijven governance-vragen.
 - Financiering/duurzaamheid van de gedeelde componenten (discovery, conformance) is een bestuurlijk besluit.
 
+## Bouwblok
+
+De verwijsindex uit dit besluit is uitgewerkt in
+[`apis/rest/discovery`](../../apis/rest/discovery/next.yaml): een manifest met per
+service `baseUrl` en `specUrl`, zonder inhoud.
+
 ## Relatie tot de strategie
 
 Voegt de governance-laag toe die de strategie niet behandelde, en houdt vast aan "data bij de bron".

--- a/architecture/adr/0007-open-data-publicatie-pull-feed.md
+++ b/architecture/adr/0007-open-data-publicatie-pull-feed.md
@@ -1,0 +1,54 @@
+# ADR-0007: Open data — publicatie via pull-feed (afbakening van ADR-0004)
+
+- **Status:** Voorgesteld
+- **Datum:** 2026-07-30
+- **Context:** [ADR-0004](./0004-ingest-cloudevents-push.md) schrijft voor dat bronnen data aanleveren door CloudEvents te POSTen. Dat besluit is genomen voor de burger-keten. De vraag is of het ook geldt wanneer de gegevens openbaar zijn en er geen burger aan hangt.
+
+## Context
+
+ADR-0004 lost een reëel probleem op: een producer die aan n consumers moet leveren, moet per consument bijhouden wat is aangekomen en wat opnieuw moet — retry-hel en gaten in data. Eén idempotent aanleverpunt haalt die last weg.
+
+Die redenering hangt aan drie aannames die bij open data geen van drieën gelden:
+
+1. **Er is een autorisatievraag.** ADR-0004 draagt `betrokkene` mee als ABAC-attribuut en vereist ondertekening (JWS) over mTLS, omdat de ontvanger moet kunnen bepalen wie wat mag zien. Bij openbare gegevens — Woo-publicaties, raadsinformatie, besluiten — is er niets af te schermen.
+2. **De producer draagt afleverlast.** Bij push is dat waar. Bij pull niet: een bron die een feed serveert, houdt geen consumentenlijst bij, kent geen mislukte afleveringen en heeft dus geen outbox of retry-worker nodig. Het alternatief "pure pull" wordt in ADR-0004 afgewezen omdat het "de retry/consistentie-last bij elke producer legt" — voor een pull-feed is het omgekeerde waar.
+3. **Het aantal afnemers is bekend en begrensd.** Bij open data is dat per definitie niet zo: journalisten, onderzoekers, andere overheden, commerciële partijen. Elke consument vooraf laten registreren of via een centraal punt laten lopen, is precies wat je bij open data niet wil.
+
+Daar komt een ervaringsfeit bij. De aanlever-route voor Woo-publicaties is één keer gestrand: het [BIT-advies over PLOOI](https://www.adviescollegeicttoetsing.nl/site/binaries/site-content/collections/documents/2022/11/28/bit-advies-plooi/BIT-advies+Platform+Open+OverheidsInformatie.pdf) (28-11-2022) concludeerde dat de gekozen oplossing leunde op een standaard die overheden moeilijk kunnen volgen, en dat een herontwerp nodig was met **minimale aansluitlast** voor overheidsorganisaties. Een bron die één feed publiceert heeft die last één keer; een bron die per landelijke voorziening een aanleverintegratie bouwt, telkens opnieuw.
+
+## Beslissing
+
+**Voor openbare gegevens publiceert de bron een pull-feed; afnemers halen op en aggregeren zelf.** ADR-0004 (CloudEvents-push) blijft gelden voor gegevens met een autorisatievraag — burgergebonden data met ABAC — en niet voor publicatie van open data.
+
+Concreet:
+
+- De bron biedt een **snapshot + cursor-feed** aan volgens [`patterns/sync-feed`](../../patterns/sync-feed/next.yaml).
+- De bron levert **niet aan** bij een centrale voorziening. Een landelijke voorziening die een totaalbeeld wil, is een afnemer als alle andere.
+- **Aggregatie is een expliciete rol**: een afnemer mag meerdere feeds samenvoegen en het resultaat als weer een feed volgens hetzelfde patroon publiceren. Zo hoeft niemand langs honderden bronnen, zonder dat er een verplichte tussenpartij ontstaat.
+- **Vindbaarheid loopt via discovery, niet via aanlevering**: een feed registreert zich in het manifest uit [`apis/rest/discovery`](../../apis/rest/discovery/next.yaml), en een landelijk register houdt feedlocaties bij — metadata, geen inhoud. Dat is de rol die [ADR-0006](./0006-per-domein-registers.md) al aan VNG/Logius toekent.
+
+## Alternatieven overwogen
+
+- **ADR-0004 ongewijzigd toepassen op open data.** Verworpen: voegt een aanleverintegratie, een PKI-afsprakenstelsel en een centrale schakel toe aan een keten die geen van drieën nodig heeft, en maakt de dekking van élke hergebruiker afhankelijk van die schakel.
+- **Beide toestaan, bron kiest.** Aantrekkelijk, maar dan moet elke afnemer beide paden ondersteunen en is het per bron onduidelijk waar de waarheid vandaan komt. Eén route per gegevenssoort is goedkoper voor de hele keten.
+- **Push naar afnemers via webhooks.** Verworpen om dezelfde reden als in ADR-0004: de producer moet dan alsnog een consumentenlijst en retry-logica bijhouden — bij een onbekend en groeiend aantal open-data-afnemers is dat het slechtste van beide werelden.
+
+## Gevolgen
+
+**Positief**
+
+- Aansluitlast bij de bron is eenmalig en onafhankelijk van het aantal afnemers.
+- Geen schakel waarop de hele keten kan stilvallen; een storing blijft lokaal.
+- Sluit aan op [ADR-0001](./0001-federatief-geen-centrale-kluis.md) (data bij de bron) en op de rolverdeling uit [ADR-0006](./0006-per-domein-registers.md).
+- Een geleidelijke overgang is mogelijk: een aggregator gebruikt per organisatie een feed zodra die bestaat, en tot die tijd de bestaande route. Er is geen moment waarop de hele keten tegelijk om moet.
+
+**Negatief / risico's**
+
+- Een bron die zijn feed slecht beschikbaar houdt, is voor iedereen slecht beschikbaar; er is geen centrale voorziening die dat opvangt. Mitigatie: aggregatoren zijn er, en `laatstBijgewerkt` in het servicedocument maakt achterstand zichtbaar in plaats van stil.
+- Zonder discovery is een federatie van feeds onvindbaar. Dit besluit leunt dus op het discovery-manifest; zonder register is de praktische bruikbaarheid beperkt tot wie de bron al kent.
+- Pollen is niet realtime. Voor open data is dat zelden bezwaarlijk; is het dat wel, dan kan een bron optioneel een stream aanbieden ([ADR-0002](./0002-levering-snapshot-plus-sse.md)) bovenop — nooit in plaats van — de feed.
+- De grens "openbaar vs. autorisatievraag" moet per gegevenssoort worden getrokken. Bij twijfel geldt ADR-0004.
+
+## Relatie tot de strategie
+
+Bakent ADR-0004 af in plaats van het te vervangen: push voor gegevens met een autorisatievraag, pull voor publicatie van open data. Daarmee wordt "data bij de bron" ([ADR-0001](./0001-federatief-geen-centrale-kluis.md)) ook waar voor de openbaarmakingsketen, en krijgt een landelijke voorziening dezelfde rol als in [ADR-0006](./0006-per-domein-registers.md): afsprakenstelsel en wegwijzer, niet de data.

--- a/architecture/adr/README.md
+++ b/architecture/adr/README.md
@@ -1,0 +1,85 @@
+# Architectural Decision Records
+
+Een ADR legt één architectuurkeuze vast: wat is besloten, waarom, welke
+alternatieven zijn verworpen en wat de gevolgen zijn. Eén bestand per
+beslissing, genummerd, en achteraf niet meer inhoudelijk gewijzigd — een nieuw
+inzicht wordt een nieuwe ADR die de oude vervangt (status `Vervangen door
+ADR-XXXX`).
+
+Het punt is dat de *redenering* bewaard blijft. Zonder ADR weet over twee jaar
+niemand meer waarom er geen centrale kluis is, en komt dat voorstel gewoon
+opnieuw langs — of erger, iemand breekt de keuze zonder te weten wat eraan hing.
+Het blok "Alternatieven overwogen" is daarom het waardevolste deel: daar staat
+wat er níet is gekozen en waarom, en dat is precies wat je nodig hebt als de
+context verandert.
+
+## Overzicht
+
+De ADR's hangen samen in [`referentie-architectuur.md`](../referentie-architectuur.md),
+dat ze per laag aanhaalt. Deze tabel geeft de andere ingang: van beslissing naar
+het herbruikbare bouwblok dat eruit volgt.
+
+| ADR | Beslissing | Status | Bouwblok |
+| --- | --- | --- | --- |
+| [0001](./0001-federatief-geen-centrale-kluis.md) | Federatief — geen centrale kluis | Voorgesteld | — (richtinggevend; werkt door in 0005 en 0007) |
+| [0002](./0002-levering-snapshot-plus-sse.md) | Levering: snapshot + resumable SSE | Voorgesteld | [`patterns/sync-feed`](../../patterns/sync-feed/next.yaml) (snapshot- en cursorbouwstenen) |
+| [0003](./0003-begrensde-query-grammatica.md) | Begrensde query-grammatica i.p.v. ElasticSearch-DSL | Voorgesteld | [`patterns/sync-feed`](../../patterns/sync-feed/next.yaml) (de cursor-paginering die deze ADR voorschrijft) |
+| [0004](./0004-ingest-cloudevents-push.md) | Ingest: CloudEvents-push, idempotent & ondertekend | Voorgesteld | [`schemas/events`](../../schemas/events/v0.0.1.json) |
+| [0005](./0005-dunne-gateway-client-side-aggregatie.md) | Dunne token/CORS-gateway + client-side aggregatie | Voorgesteld | [`patterns/federated-auth`](../../patterns/federated-auth/next.yaml) |
+| [0006](./0006-per-domein-registers.md) | Per-domein registers & governance | Voorgesteld | [`apis/rest/discovery`](../../apis/rest/discovery/next.yaml) (verwijsindex) |
+| [0007](./0007-open-data-publicatie-pull-feed.md) | Open data: publicatie via pull-feed (bakent 0004 af) | Voorgesteld | [`patterns/sync-feed`](../../patterns/sync-feed/next.yaml) |
+
+Patronen zonder ADR — er ligt geen architectuurbesluit aan ten grondslag, ze
+zijn overgenomen uit bestaande conventies:
+
+| Patroon | Herkomst | Let op |
+| --- | --- | --- |
+| [`patterns/pagination`](../../patterns/pagination/0.0.1.yaml) | ZGW-conventie (`page`/`pageSize`/`count`) | ADR-0003 schrijft cursor-paginering voor; voor endpoints waar een afnemer een kopie bijhoudt geldt [`patterns/sync-feed`](../../patterns/sync-feed/next.yaml) |
+| [`patterns/error-responses`](../../patterns/error-responses/v0.0.1.yaml) | Landelijke API-strategie | Verwijst nog naar RFC 7807; actueel is RFC 9457 (zie [`apis/FEEDBACK.md`](../../apis/FEEDBACK.md), rode draad 4) |
+| [`patterns/file-upload`](../../patterns/file-upload/next.yaml) | Two-step pre-signed upload, praktijkpatroon | — |
+
+## Conventie: ADR ↔ patroon
+
+Een ADR beschrijft het **waarom**, een patroon het herbruikbare **hoe**. Ze
+horen naar elkaar te verwijzen, zodat je vanaf een OpenAPI-fragment de
+onderbouwing terugvindt en vanaf een besluit het bouwblok.
+
+- Een patroon dat uit een ADR volgt, opent met een commentaarregel
+  `# Implementeert: ADR-XXXX (…)`.
+- Een patroon zonder ADR benoemt zijn herkomst in één regel, zodat "geen ADR"
+  een keuze is en geen omissie.
+- Deze index is de autoritatieve afbeelding tussen beide. Reeds uitgebrachte
+  patroonversies (`vX.Y.Z.yaml`) worden er niet meer voor aangepast; nieuwe
+  verwijzingen landen in `next.yaml` of hier.
+
+## Een nieuwe ADR schrijven
+
+Nummer oplopend, bestandsnaam `NNNN-korte-titel.md`, en dit stramien:
+
+```markdown
+# ADR-NNNN: Titel
+
+- **Status:** Voorgesteld | Geaccepteerd | Vervangen door ADR-XXXX
+- **Datum:** JJJJ-MM-DD
+- **Context:** één regel — waar komt deze vraag vandaan
+
+## Context
+Wat speelt er, welke vraag moet beantwoord worden, welke krachten spelen mee.
+
+## Beslissing
+Wat is gekozen. Actief geformuleerd, zonder slagen om de arm.
+
+## Alternatieven overwogen
+Per alternatief: wat het was en waarom het is afgevallen.
+
+## Gevolgen
+**Positief** — wat dit oplevert.
+**Negatief / risico's** — eerlijk, inclusief wat je ervoor inlevert.
+
+## Relatie tot de strategie
+Hoe dit zich verhoudt tot de referentiearchitectuur en aangrenzende ADR's.
+```
+
+Volgt er een herbruikbaar bouwblok uit? Voeg dat als patroon toe onder
+`patterns/`, verwijs heen en weer, en zet de regel in de tabel hierboven.
+Zie [`CONTRIBUTING.md`](../../CONTRIBUTING.md) voor het bredere proces.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -8,6 +8,12 @@ Patronen zijn generieke, herbruikbare oplossingen of afspraken voor veelvoorkome
 
 Wanneer elke API op een andere manier zijn foutmeldingen teruggeeft of paginering oplost, wordt het voor afnemers (ontwikkelaars) onnodig complex en tijdsintensief om applicaties te koppelen. Patronen zorgen direct voor een uniforme integratiearchitectuur: "Write once, run everywhere".
 
+## Relatie tot architectuurbesluiten
+
+Een patroon beschrijft *hoe* iets herbruikbaar wordt opgelost; het bijbehorende **Architectural Decision Record (ADR)** beschrijft *waarom* die keuze is gemaakt en welke alternatieven zijn afgevallen. Patronen die uit een besluit volgen, openen daarom met een regel `# Implementeert: ADR-XXXX`, en het besluit verwijst terug naar het patroon.
+
+Het overzicht van beide staat in [`architecture/adr/README.md`](/?doc=architecture/adr/README.md): per besluit het bouwblok dat eruit volgt, en per patroon zonder besluit de herkomst ervan.
+
 ## Relatie tot APIs en Schemas
 
 - **APIs**: APIs importeren deze patronen direct in hun OpenAPI specificatie. Een `GET /zaken` endpoint maakt bijvoorbeeld zonder meer gebruik van het centrale `pagination.yaml` patroon voor het bepalen van hoe resultaten verdeeld worden over pagina's.

--- a/patterns/federated-auth/next.yaml
+++ b/patterns/federated-auth/next.yaml
@@ -4,6 +4,10 @@
 # zonder aggregerende tussenlaag. Herkomst: architectuurdiscussie over
 # "client haalt data direct bij de bron op" (bijv. NL Portal frontend
 # rechtstreeks naar Open Klant, geen backend-per-portaal ertussen).
+#
+# Implementeert: ADR-0005 (dunne token/CORS-gateway + client-side aggregatie),
+# binnen de lijn van ADR-0001 (federatief, data bij de bron).
+# Zie ../../architecture/adr/README.md
 
 title: Federatief-ready authenticatie
 description: |

--- a/patterns/file-upload/next.yaml
+++ b/patterns/file-upload/next.yaml
@@ -1,3 +1,5 @@
+# Herkomst: praktijkpatroon (two-step upload met pre-signed URL); geen
+# onderliggend architectuurbesluit. Zie ../../architecture/adr/README.md
 title: File Upload
 description: |
   Beschrijft het API-gedrag, de foutafhandeling en de (HTTP) OpenAPI request/response contracten voor het two-step (pre-signed URL) uploadproces.

--- a/patterns/sync-feed/next.yaml
+++ b/patterns/sync-feed/next.yaml
@@ -1,0 +1,265 @@
+# Sync-Feed Pattern
+# Herbruikbare bouwstenen voor een feed waarop een afnemer betrouwbaar kan
+# synchroniseren: een snapshot voor de begintoestand en een cursor-feed voor
+# de wijzigingen daarna.
+#
+# Implementeert: ADR-0007 (open data: publicatie via pull-feed).
+# Levert daarnaast de cursor- en snapshotbouwstenen voor ADR-0002 (levering:
+# snapshot + tail) en de cursor-paginering die ADR-0003 voorschrijft.
+# Zie ../../architecture/adr/README.md
+
+title: Sync-feed (snapshot + cursor)
+description: |
+  Maakt een bron synchroniseerbaar: een afnemer haalt één keer de huidige stand
+  op en blijft daarna bij met een cursor, zonder ooit alles opnieuw te hoeven
+  ophalen en zonder wijzigingen te missen.
+
+  **Waarom niet gewoon paginering met een datumfilter.** Dat is de standaard
+  eerste poging, en hij lekt op twee manieren. `offset`/`page` schuift op zodra
+  er tijdens het pagineren records bijkomen — de afnemer slaat er dan stil een
+  over. En een tijdstempel is geen betrouwbare sleutel: klokken lopen uiteen,
+  meerdere records delen dezelfde milliseconde, en een wijziging die met
+  terugwerkende kracht bekend wordt krijgt een tijdstempel in het verleden,
+  waardoor een afnemer die al verder was hem nooit meer ziet. Beide fouten zijn
+  onzichtbaar voor de afnemer: het resultaat is een gat in zijn kopie, niet een
+  foutmelding. Zie [`patterns/pagination`](../pagination/0.0.1.yaml) voor
+  gewone lijst-endpoints; gebruik dít patroon zodra een afnemer een kopie
+  bijhoudt.
+
+  **De vier garanties.** Een implementatie van dit patroon belooft:
+
+  1. Elk record heeft een `sequenceNumber` dat de bron **bij vastlegging**
+     toekent en dat per feed monotoon oploopt.
+  2. Er wordt nooit een record ingevoegd vóór een `sequenceNumber` dat een
+     afnemer al heeft kunnen lezen. Wat later bekend wordt, krijgt een hoger
+     nummer.
+  3. De feed wordt altijd oplopend uitgeleverd. Een aflopende weergave is een
+     presentatiekwestie, geen synchronisatiemechanisme.
+  4. Gaten in de reeks komen alleen voor als expliciet `redact`-record, nooit
+     stilzwijgend.
+
+  **Cursors.** Een `cursor` is opaak: bewaar hem, geef hem mee, en interpreteer
+  hem niet. Hij duidt een positie in de **volledige** feed aan; filters worden
+  daarná toegepast, zodat een cursor geldig blijft als een afnemer zijn filter
+  wijzigt. `head` geeft het hoogste `sequenceNumber` op het moment van
+  antwoorden, zodat een afnemer zijn achterstand kan zien; `hasMore: false`
+  betekent "je bent bij".
+
+  **Koude start.** Een afnemer begint bij het snapshot-endpoint en neemt van de
+  **eerste** pagina de `feedCursor` over. Die wordt vastgesteld vóórdat de
+  snapshotrijen worden gelezen — doe je het erna, dan vallen wijzigingen die
+  tijdens het doorlopen binnenkomen tussen wal en schip.
+
+  **Deduplicatie.** Leg geen nieuw record vast wanneer de `contentHash` gelijk
+  is aan de vorige toestand van dezelfde resource. Zonder die afspraak levert
+  een herindexatie aan de bronkant een storm van no-op-records op, en haalt
+  iedere afnemer bij elke herverwerking de hele dataset opnieuw op.
+
+  **Verwijderen en redactie.** `delete` betekent: haal deze resource uit je
+  kopie, index, caches en afgeleide producten. `redact` betekent hetzelfde,
+  plus dat de bron eerdere inhoud uit de feedhistorie heeft verwijderd — nodig
+  wanneer gepubliceerde inhoud daar niet had mogen staan. Dat is het antwoord
+  op de AVG-bezwaren tegen een append-only log uit ADR-0002: een log die
+  redigeerbaar is, met de gaten expliciet benoemd in plaats van stil.
+  Houd records daarom compact: metadata en verwijzingen, geen bijlage-inhoud.
+
+  **Aggregatoren.** Een afnemer mag meerdere feeds samenvoegen en het resultaat
+  als *weer een feed volgens dit patroon* publiceren; `sequenceNumber` en
+  `cursor` gelden per feed, dus een aggregator kent zijn eigen reeks toe.
+  Vier verplichtingen houden de keten heel:
+
+  1. Geef de resource-identificatie van de bron onveranderd door; eigen
+     identifiers mogen ernaast staan, niet in de plaats.
+  2. Propageer `redact` — een intrekking die bij de eerste hop blijft hangen is
+     geen intrekking.
+  3. Publiceer géén `delete` wanneer een bovenliggende feed onbereikbaar is: de
+     resources zijn niet verdwenen, jij bent tijdelijk blind. Dit is de fout
+     die iedereen één keer maakt, en hij wist in één keer een hele bron.
+  4. Houd verrijking (afgeleide tekst, thumbnails, zoekindexen) in je eigen
+     API, niet in de feed.
+
+  **Hoe te gebruiken.** Dit patroon is domeinonafhankelijk en laat twee velden
+  aan de implementerende API over: `resource` (hoe een resource in dat domein
+  wordt geïdentificeerd) en `data` (de toestand zelf). Neem `FeedRecordBasis`
+  op met `allOf` en vul die twee aan:
+
+  ```yaml
+  FeedRecord:
+    allOf:
+      - $ref: "../../patterns/sync-feed/next.yaml#/schemas/FeedRecordBasis"
+      - type: object
+        required: [resource]
+        properties:
+          resource:
+            $ref: "#/components/schemas/ResourceSleutel"
+          data:
+            $ref: "#/components/schemas/MijnResource"
+  ```
+
+parameters:
+  cursor:
+    name: cursor
+    in: query
+    required: false
+    description: |
+      Opake positie-aanduiding uit een eerder antwoord. Laat weg om bij het
+      begin te starten. Behandel de waarde als ondeelbaar: het formaat is geen
+      contract en kan wijzigen.
+    schema:
+      type: string
+    example: "c2VxOjEyMzQ1"
+  limit:
+    name: limit
+    in: query
+    required: false
+    description: Maximum aantal records per pagina.
+    schema:
+      type: integer
+      minimum: 1
+      maximum: 1000
+      default: 500
+
+schemas:
+  Operatie:
+    type: string
+    enum:
+      - upsert
+      - delete
+      - redact
+    description: |
+      - `upsert`: de volledige toestand van de resource (replace-semantiek).
+        Bewust geen onderscheid tussen aanmaken en wijzigen: voor een afnemer
+        is dat hetzelfde ("vervang wat ik had"), en veel bronsystemen kunnen
+        het verschil niet betrouwbaar leveren.
+      - `delete`: de resource bestaat niet meer of is niet langer beschikbaar.
+      - `redact`: als `delete`, plus: eerdere inhoud over deze resource is uit
+        de feedhistorie verwijderd.
+    example: upsert
+  FeedRecordBasis:
+    type: object
+    description: |
+      De domeinonafhankelijke velden van een feedrecord. Vul aan met `resource`
+      (identificatie in het eigen domein) en `data` (de toestand).
+    required:
+      - sequenceNumber
+      - op
+      - storedAt
+    properties:
+      sequenceNumber:
+        type: integer
+        minimum: 1
+        description: Door de bron toegekend bij vastlegging, per feed monotoon oplopend. De ordeningssleutel van de feed.
+        example: 42
+      op:
+        $ref: "#/schemas/Operatie"
+      storedAt:
+        type: string
+        format: date-time
+        description: Tijdstip waarop de bron deze wijziging in de feed heeft vastgelegd.
+        example: "2026-03-12T10:00:05Z"
+      gewijzigdOp:
+        type: string
+        format: date-time
+        description: |
+          Tijdstip van de wijziging in het bronsysteem, als dat wordt
+          bijgehouden. Informatief: niet monotoon, dus niet geschikt om op te
+          synchroniseren.
+        example: "2026-03-12T10:00:00Z"
+      contentHash:
+        type: string
+        pattern: "^sha256:[0-9a-f]{64}$"
+        description: |
+          Hash over de inhoud van `data`. Dient als deduplicatiesleutel (geen
+          nieuw record bij een gelijke hash) en als ordeningssleutel per
+          resource. Aanwezig bij `op: upsert`.
+        example: "sha256:9f2c1e0b7d4a5c6e8f0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60"
+      resourceUrl:
+        type: string
+        format: uri
+        description: Waar deze resource bij de bron te vinden is. Een adres, geen identiteit — sleutel op de resource-identificatie van het eigen domein.
+      geredigeerdeSequenceNumbers:
+        type: array
+        description: |
+          Alleen bij `op: redact`: de `sequenceNumber`s waarvan de inhoud uit de
+          feedhistorie is verwijderd. Een afnemer die die records eerder ophaalde,
+          verwijdert de gegevens ook uit zijn eigen kopie, caches en afgeleide
+          producten. Dit zijn de enige toegestane gaten in de reeks.
+        items:
+          type: integer
+        example: [17, 29]
+      herkomst:
+        type: object
+        description: |
+          Alleen door een aggregator gevuld: uit welke feed dit record komt.
+          Maakt de keten traceerbaar en laat zien of twee aggregatoren dezelfde
+          bron doorgeven. Een bron zelf laat dit weg.
+        required:
+          - feedUrl
+        properties:
+          feedUrl:
+            type: string
+            format: uri
+            description: De feed waaruit dit record is overgenomen.
+          sequenceNumber:
+            type: integer
+            description: Het `sequenceNumber` dat dit record in die feed had. Geldt alleen daar.
+  FeedPaginaBasis:
+    type: object
+    description: |
+      Het antwoord van een feed-endpoint. Vul aan met `records` (een array van
+      het eigen FeedRecord).
+    required:
+      - cursor
+      - head
+      - hasMore
+    properties:
+      cursor:
+        type: string
+        description: Positie ná het laatste record op deze pagina. Bewaren en meegeven bij de volgende aanroep.
+        example: "c2VxOjEyMzQ1"
+      head:
+        type: integer
+        description: Het hoogste `sequenceNumber` in de feed op het moment van antwoorden. Het verschil met het laatste record is de achterstand van de afnemer.
+        example: 120345
+      hasMore:
+        type: boolean
+        description: "`false` betekent: je bent bij. Bewaar de cursor en poll later opnieuw."
+        example: true
+      next:
+        type:
+          - string
+          - "null"
+        format: uri
+        description: "Volledige URL voor de volgende pagina, of `null` bij `hasMore: false`."
+  SnapshotPaginaBasis:
+    type: object
+    description: |
+      Het antwoord van een snapshot-endpoint: de huidige stand, als startpunt
+      voor een nieuwe afnemer. Vul aan met `records`.
+    required:
+      - feedCursor
+      - hasMore
+    properties:
+      feedCursor:
+        type: string
+        description: |
+          De cursor waarmee je na het doorlopen van dit snapshot verdergaat op
+          de feed. Neem de waarde van de **eerste** pagina: die is vastgesteld
+          vóórdat de snapshotrijen werden gelezen, zodat wijzigingen tijdens het
+          doorlopen niet worden gemist. Wordt op elke pagina meegegeven om
+          hervatten eenvoudig te houden.
+        example: "c2VxOjEyMDAwMA"
+      cursor:
+        type:
+          - string
+          - "null"
+        description: Positie voor de volgende snapshotpagina, of `null` als dit de laatste is.
+      hasMore:
+        type: boolean
+        example: true
+      next:
+        type:
+          - string
+          - "null"
+        format: uri
+        description: Volledige URL voor de volgende pagina.


### PR DESCRIPTION

## Waarom

De ADR's en de patterns staan nu los van elkaar. Geen enkele verwijzing in
beide richtingen: `patterns/` noemt nergens een ADR-nummer, en de ADR's noemen
nergens een patroon. De enige provenance is één zin in de header van
`federated-auth` ("Herkomst: architectuurdiscussie over…") zonder nummer of
link.

Dat is jammer, want de twee vullen elkaar aan: een ADR beschrijft het *waarom*
inclusief de verworpen alternatieven, een patroon het herbruikbare *hoe*. Zonder
koppeling vertelt een OpenAPI-fragment niet welk besluit eronder ligt, en een
besluit niet welk bouwblok eruit volgde. Het "Alternatieven overwogen"-blok is
juist het waardevolste deel van een ADR — dat wil je kunnen vinden vanaf de plek
waar je aan het bouwen bent.

## Wat deze PR doet

**De conventie**, vastgelegd in `CONTRIBUTING.md` en `architecture/adr/README.md`:

- een patroon dat uit een ADR volgt opent met `# Implementeert: ADR-XXXX (…)`;
- de ADR krijgt een korte `## Bouwblok`-sectie die terugwijst;
- de tabel in de ADR-index is de autoritatieve afbeelding tussen beide;
- een patroon zónder ADR benoemt in één regel zijn herkomst, zodat "geen ADR"
  zichtbaar een keuze is en geen omissie.

**Toegepast op wat er ligt**: ADR-0001 t/m 0006 krijgen een `## Bouwblok`-sectie,
`federated-auth` en `file-upload` een herkomstregel. Reeds uitgebrachte
patroonversies (`vX.Y.Z.yaml`) zijn hiervoor bewust niet aangepast — die staan
in de index.

**`architecture/adr/README.md`** is nieuw: index met status en bouwblok per ADR,
de patronen zonder ADR met hun herkomst, de conventie, en het stramien voor een
nieuwe ADR.

Twee dingen die daarbij opvielen en die de index nu expliciet maakt:

- `patterns/pagination` gebruikt `page`/`pageSize`, terwijl ADR-0003
  cursor-paginering voorschrijft. Die spanning was nergens zichtbaar.
- `patterns/error-responses` verwijst naar RFC 7807 waar 9457 actueel is —
  precies wat `apis/FEEDBACK.md` (rode draad 4) al signaleert. Niet gewijzigd:
  het is een uitgebrachte versie.

En een kleine correctie: `CONTRIBUTING.md` verwees voor ADR's/RFC's naar
`docs/rfcs/`, een map die niet bestaat. Nu naar `architecture/adr/`.

## Het nieuwe paar

Als eerste dat de conventie volgt, en meteen de aanleiding voor deze PR:

**ADR-0007 — open data: publicatie via pull-feed.** Dit bakent ADR-0004
(CloudEvents-push) af in plaats van het te vervangen. De redenering van ADR-0004
hangt aan drie aannames die bij openbare gegevens geen van drieën gelden:

1. *Er is een autorisatievraag.* ADR-0004 draagt `betrokkene` mee als
   ABAC-attribuut en vereist JWS over mTLS. Bij Woo-publicaties en
   raadsinformatie is er niets af te schermen.
2. *De producer draagt afleverlast.* Bij push klopt dat. Bij pull niet: een bron
   die een feed serveert houdt geen consumentenlijst bij, kent geen mislukte
   afleveringen, en heeft dus geen outbox of retry-worker nodig. ADR-0004 wijst
   "pure pull" af omdat het "de retry/consistentie-last bij elke producer legt" —
   voor een pull-feed is het omgekeerde waar.
3. *Het aantal afnemers is bekend en begrensd.* Bij open data per definitie niet:
   journalisten, onderzoekers, andere overheden, commerciële partijen.

Daar komt een ervaringsfeit bij: de aanlever-route voor Woo-publicaties is één
keer gestrand. Het BIT-advies over PLOOI (28-11-2022) concludeerde dat de
gekozen oplossing leunde op een standaard die overheden moeilijk kunnen volgen,
en dat een herontwerp nodig was met **minimale aansluitlast**. Een bron die één
feed publiceert heeft die last één keer; een bron die per landelijke voorziening
een aanleverintegratie bouwt, telkens opnieuw.

Het besluit sluit aan op ADR-0001 (data bij de bron) en geeft een landelijke
voorziening dezelfde rol als ADR-0006 al voorschrijft: afsprakenstelsel en
verwijsindex, geen inhoud.

**`patterns/sync-feed`** is het bouwblok: `cursor`/`limit`-parameters,
`FeedRecordBasis`, `FeedPaginaBasis`, `SnapshotPaginaBasis`. Met de vier
garanties die een feed synchroniseerbaar maken (monotoon `sequenceNumber`
toegekend bij vastlegging, nooit invoegen vóór een gelezen positie, altijd
oplopend, gaten alleen als expliciet `redact`), `contentHash`-deduplicatie, en
de verplichtingen voor aggregatoren.

Twee daarvan raken bestaande besluiten direct:

- **`redact` is het antwoord op het AVG-bezwaar uit ADR-0002.** Die ADR verwerpt
  een publiek event-sourced log onder meer omdat "een delete-event de al
  gerepliceerde PII niet verwijdert". Een log met een expliciete
  redactie-operatie, waarbij de gaten in de reeks benoemd worden in plaats van
  stil te blijven, maakt dat wél uitvoerbaar.
- **De cursor-paginering** die ADR-0003 voorschrijft bestond nog niet als
  herbruikbaar fragment; nu wel.

## Niet in deze PR

Het portaal publiceert `architecture/` nog niet: `vite.config.js` globt
`patterns/**` en `docs/**`, de `build`-stap kopieert `docs apis schemas patterns
services bpmn arazzo *.md` naar `dist/`, en de sidebar heeft handgeschreven
links naar `docs/*.md`. Drie kleine toevoegingen dus — maar precies die drie
bestanden hebben lokale wijzigingen voor arazzo/npm-publicatie, dus ik heb ze
met rust gelaten. Losse commit zodra dat werk binnen is:

```
vite.config.js        + "architecture/**/*.md" in de watcher-lijst en het change-filter
package.json (build)  + architecture in de cp-lijst
docs/src/Sidebar.jsx  + nav-item "Architectuur" → ?doc=architecture/adr/README.md
```

Architectuurbesluiten publiceren is nogal het punt van ADR's, dus dat is het
waard.

## Relatie tot de ORI-PR

`patterns/sync-feed` is de generieke versie van het contract dat parallel is
voorgesteld bij
[ODS-Open-Raadsinformatie](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie)
(event polling 0.0.2). Landt het patroon hier, dan kan die specificatie ernaar
verwijzen in plaats van de definities te herhalen — en is het meteen een tweede
gebruiker, wat volgens `CONTRIBUTING.md` §5 de drempel is om een gedeeld
bouwblok te promoveren.

Volledige openheid over de pet: wij bouwen met OpenBesluitvorming zelf een
aggregator op deze feeds, dus ADR-0007 raakt ons eigen werk. De onderbouwing
staat of valt daar niet mee — de drie aannames uit ADR-0004 gelden bij open data
voor iedereen niet — maar het hoort erbij vermeld te worden.
